### PR TITLE
Make Yoda conditions "always"

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = {
 		'radix': 2,
 		'vars-on-top': 2,
 		'wrap-iife': 2,
-		'yoda': 2,
+		'yoda': [2, 'always'],
 		// Strict Mode
 		'strict': 2,
 		// Variables


### PR DESCRIPTION
The default is never:  http://eslint.org/docs/rules/yoda

Which is contradictory to: https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#yoda-conditions
