### PR TITLE
chore: Add NodeJS v8 to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+- '8'
 - '7'
 - '6'
 - '4'


### PR DESCRIPTION
Node.js v8 was released today: https://nodejs.org/en/blog/release/v8.0.0/

A couple of highlights from the release post:

> _"npm, Inc. recently announced the release of version 5.0.0 of the npm client and we are happy to include this significant new version within Node.js 8.0.0."_

> _"Node.js 8 is the next release line to enter Long Term Support (LTS). This is scheduled to happen in October 2017. Once Node.js 8 transitions to LTS, it will receive the code name Carbon."_

> _"Note that, when referring to Node.js release versions, we have dropped the "v" in Node.js 8. Previous versions were commonly referred to as v0.10, v0.12, v4, v6, etc. In order to avoid confusion with V8, the underlying JavaScript engine, we've dropped the "v" and call it Node.js 8."_