### PR TITLE
Use valid JSON syntax for usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ $ npm install eslint-config-wordpress
 
 ## Usage
 
-Add this to your .eslintrc file:
+Add this to your `.eslintrc` file:
 
-```yaml
-extends: 'wordpress'
+```json
+"extends": "wordpress"
 ```
 
 ## [License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ $ npm install eslint-config-wordpress
 
 ## Usage
 
-Add this to your `.eslintrc` file:
+Add this to your `.eslintrc.json` file:
 
 ```json
 "extends": "wordpress"
 ```
+
+If you are using YAML or JavaScript for your [ESLint configuration file format](http://eslint.org/docs/user-guide/configuring#configuration-file-formats) ensure you use the correct syntax for the language used.
 
 ## [License](LICENSE)


### PR DESCRIPTION
This could fix a parse error when someone adds the line to a `.eslintrc` which is strict JSON.