### PR TITLE
Fix yoda conditions and camel case requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,9 @@ module.exports = {
 		// Require immediate function invocation to be wrapped in parentheses
 		'wrap-iife': 'error',
 		// Require or disallow Yoda conditions
-		yoda: ['error', 'always'],
+		yoda: ['error', 'always', {
+			onlyEquality: true
+		}],
 		// Strict Mode
 		// Variables
 		// Stylistic Issues
@@ -46,7 +48,7 @@ module.exports = {
 		'brace-style': 'error',
 		// Require camel case names
 		camelcase: ['error', {
-			properties: 'always',
+			properties: 'never',
 		}],
 		// Disallow or enforce trailing commas
 		'comma-dangle': ['error', 'never'],


### PR DESCRIPTION
* Yoda conditions are required for equality only
* Camel case is not required for properties. Some built-in WP properties aren't camel-cased.

See JSCS version of this preset:
https://github.com/jscs-dev/node-jscs/blob/master/presets/wordpress.json