### PR TITLE
chore: bump minimum Node.js required version to `8.9.3`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
 - '8'
-- '6'
+- '9'
 cache:
   directories:
     - $HOME/.npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # HEAD
 
-* chore: Bump minimum Node.js required version to `6.9.1`
+* chore: Bump minimum Node.js required version to `8.9.3`
 * chore: Switch from AVA to Jest for tests.
 
 # 2.0.0

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "https://netweb.com.au"
 	},
 	"engines": {
-		"node": ">=6.9.1"
+		"node": ">=8.9.3"
 	},
 	"main": "index.js",
 	"files": [


### PR DESCRIPTION
The minimum Node.js required version should match WordPress Core. 

• https://core.trac.wordpress.org/ticket/35105
• https://core.trac.wordpress.org/changeset/42461